### PR TITLE
fix: Touch gesture issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-04-26
+
+### Fixed
+
+- Fixed a mobile interaction bug where swiping on a boss card could incorrectly mark that boss as faced (Issue #7)
+- Fixed a mobile interaction bug where a long-press reroll could be followed by an unintended boss action on finger release (Issue #8)
+
 ## [1.0.0] - 2026-04-21
 
 ### Added
@@ -38,5 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release validation CI check for PRs targeting main (version increment, changelog entry, empty Unreleased section)
 - CHANGELOG.md following Keep a Changelog 1.1.0 conventions
 
-[Unreleased]: https://github.com/bwyatt/blind-keeper/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/bwyatt/blind-keeper/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/bwyatt/blind-keeper/releases/tag/v1.0.1
 [1.0.0]: https://github.com/bwyatt/blind-keeper/releases/tag/v1.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blind-keeper",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blind-keeper",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "preact": "^10.29.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blind-keeper",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/app.css
+++ b/src/app.css
@@ -314,7 +314,7 @@
   position: absolute;
   inset: 0;
   cursor: pointer;
-  touch-action: none;
+  touch-action: pan-y;
   -webkit-user-select: none;
   user-select: none;
   z-index: 1;

--- a/src/components/BossGrid.test.tsx
+++ b/src/components/BossGrid.test.tsx
@@ -106,6 +106,8 @@ describe('BossGrid', () => {
   });
 
   it('does not trigger face or reroll on swipe movement beyond threshold', () => {
+    vi.useFakeTimers();
+
     const onFace = vi.fn();
     const onReroll = vi.fn();
     const { getByLabelText } = render(
@@ -124,6 +126,14 @@ describe('BossGrid', () => {
     fireEvent.pointerDown(touchArea, { clientX: 10, clientY: 10 });
     fireEvent.pointerMove(touchArea, { clientX: 30, clientY: 30 });
     fireEvent.pointerUp(touchArea);
+
+    expect(onFace).not.toHaveBeenCalled();
+    expect(onReroll).not.toHaveBeenCalled();
+
+    // Advance past the long-press threshold to confirm the timer was actually canceled
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
 
     expect(onFace).not.toHaveBeenCalled();
     expect(onReroll).not.toHaveBeenCalled();
@@ -176,13 +186,16 @@ describe('BossGrid', () => {
   });
 
   it('still faces on quick tap without movement', () => {
+    vi.useFakeTimers();
+
     const onFace = vi.fn();
+    const onReroll = vi.fn();
     const { getByLabelText } = render(
       <BossGrid
         eligibleBosses={sampleBosses}
         rerolledBosses={[]}
         onFace={onFace}
-        onReroll={() => {}}
+        onReroll={onReroll}
       />,
     );
 
@@ -195,5 +208,12 @@ describe('BossGrid', () => {
 
     expect(onFace).toHaveBeenCalledTimes(1);
     expect(onFace).toHaveBeenCalledWith('the-hook');
+
+    // Advance past the long-press threshold to confirm the timer was canceled by pointerUp
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    expect(onReroll).not.toHaveBeenCalled();
   });
 });

--- a/src/components/BossGrid.test.tsx
+++ b/src/components/BossGrid.test.tsx
@@ -1,5 +1,6 @@
-import { render, fireEvent } from '@testing-library/preact';
-import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, act } from '@testing-library/preact';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { useState } from 'preact/hooks';
 import { BossGrid } from './BossGrid.tsx';
 import type { BossBlind } from '../data/bosses.ts';
 
@@ -10,6 +11,10 @@ const sampleBosses: BossBlind[] = [
 ];
 
 describe('BossGrid', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('renders all eligible bosses', () => {
     const { getByText } = render(
       <BossGrid
@@ -124,33 +129,50 @@ describe('BossGrid', () => {
     expect(onReroll).not.toHaveBeenCalled();
   });
 
-  it('fires reroll once on long press and does not face on pointer up', () => {
+  it('fires reroll once on long press and does not face when pointer up lands on newly-exposed boss', () => {
     vi.useFakeTimers();
 
     const onFace = vi.fn();
     const onReroll = vi.fn();
-    const { getByLabelText } = render(
-      <BossGrid
-        eligibleBosses={sampleBosses}
-        rerolledBosses={[]}
-        onFace={onFace}
-        onReroll={onReroll}
-      />,
-    );
 
-    const touchArea = getByLabelText(
+    function StatefulBossGrid() {
+      const [rerolledBosses, setRerolledBosses] = useState<string[]>([]);
+      return (
+        <BossGrid
+          eligibleBosses={sampleBosses}
+          rerolledBosses={rerolledBosses}
+          onFace={onFace}
+          onReroll={(id) => {
+            onReroll(id);
+            setRerolledBosses((prev) => [...prev, id]);
+          }}
+        />
+      );
+    }
+
+    const { getByLabelText, queryByLabelText } = render(<StatefulBossGrid />);
+
+    const hookTouchArea = getByLabelText(
       'The Hook. Tap to face, long press to reroll',
     );
 
-    fireEvent.pointerDown(touchArea, { clientX: 10, clientY: 10 });
-    vi.advanceTimersByTime(500);
-    fireEvent.pointerUp(touchArea);
+    // Long press on The Hook triggers a reroll, removing The Hook from the grid
+    fireEvent.pointerDown(hookTouchArea, { clientX: 10, clientY: 10 });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
 
+    expect(queryByLabelText('The Hook. Tap to face, long press to reroll')).toBeNull();
     expect(onReroll).toHaveBeenCalledTimes(1);
     expect(onReroll).toHaveBeenCalledWith('the-hook');
-    expect(onFace).not.toHaveBeenCalled();
 
-    vi.useRealTimers();
+    // The subsequent pointerUp lands on The Club, now exposed after the reroll
+    const clubTouchArea = getByLabelText(
+      'The Club. Tap to face, long press to reroll',
+    );
+    fireEvent.pointerUp(clubTouchArea);
+
+    expect(onFace).not.toHaveBeenCalled();
   });
 
   it('still faces on quick tap without movement', () => {

--- a/src/components/BossGrid.test.tsx
+++ b/src/components/BossGrid.test.tsx
@@ -99,4 +99,79 @@ describe('BossGrid', () => {
     fireEvent.keyDown(touchArea, { key: 'Enter' });
     expect(onFace).toHaveBeenCalledWith('the-hook');
   });
+
+  it('does not trigger face or reroll on swipe movement beyond threshold', () => {
+    const onFace = vi.fn();
+    const onReroll = vi.fn();
+    const { getByLabelText } = render(
+      <BossGrid
+        eligibleBosses={sampleBosses}
+        rerolledBosses={[]}
+        onFace={onFace}
+        onReroll={onReroll}
+      />,
+    );
+
+    const touchArea = getByLabelText(
+      'The Hook. Tap to face, long press to reroll',
+    );
+
+    fireEvent.pointerDown(touchArea, { clientX: 10, clientY: 10 });
+    fireEvent.pointerMove(touchArea, { clientX: 30, clientY: 30 });
+    fireEvent.pointerUp(touchArea);
+
+    expect(onFace).not.toHaveBeenCalled();
+    expect(onReroll).not.toHaveBeenCalled();
+  });
+
+  it('fires reroll once on long press and does not face on pointer up', () => {
+    vi.useFakeTimers();
+
+    const onFace = vi.fn();
+    const onReroll = vi.fn();
+    const { getByLabelText } = render(
+      <BossGrid
+        eligibleBosses={sampleBosses}
+        rerolledBosses={[]}
+        onFace={onFace}
+        onReroll={onReroll}
+      />,
+    );
+
+    const touchArea = getByLabelText(
+      'The Hook. Tap to face, long press to reroll',
+    );
+
+    fireEvent.pointerDown(touchArea, { clientX: 10, clientY: 10 });
+    vi.advanceTimersByTime(500);
+    fireEvent.pointerUp(touchArea);
+
+    expect(onReroll).toHaveBeenCalledTimes(1);
+    expect(onReroll).toHaveBeenCalledWith('the-hook');
+    expect(onFace).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it('still faces on quick tap without movement', () => {
+    const onFace = vi.fn();
+    const { getByLabelText } = render(
+      <BossGrid
+        eligibleBosses={sampleBosses}
+        rerolledBosses={[]}
+        onFace={onFace}
+        onReroll={() => {}}
+      />,
+    );
+
+    const touchArea = getByLabelText(
+      'The Hook. Tap to face, long press to reroll',
+    );
+
+    fireEvent.pointerDown(touchArea, { clientX: 10, clientY: 10 });
+    fireEvent.pointerUp(touchArea);
+
+    expect(onFace).toHaveBeenCalledTimes(1);
+    expect(onFace).toHaveBeenCalledWith('the-hook');
+  });
 });

--- a/src/components/BossGrid.tsx
+++ b/src/components/BossGrid.tsx
@@ -47,6 +47,8 @@ function BossCard({ boss, onFace, onReroll }: BossCardProps) {
   const [pressing, setPressing] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const didLongPress = useRef(false);
+  const interactionCanceled = useRef(false);
+  const actionConsumed = useRef(false);
   const startPos = useRef<{ x: number; y: number } | null>(null);
 
   const clearTimer = useCallback(() => {
@@ -63,10 +65,16 @@ function BossCard({ boss, onFace, onReroll }: BossCardProps) {
 
   const handlePointerDown = useCallback((e: PointerEvent) => {
     didLongPress.current = false;
+    interactionCanceled.current = false;
+    actionConsumed.current = false;
     startPos.current = { x: e.clientX, y: e.clientY };
     setPressing(true);
     timerRef.current = setTimeout(() => {
+      if (interactionCanceled.current || actionConsumed.current) {
+        return;
+      }
       didLongPress.current = true;
+      actionConsumed.current = true;
       setPressing(false);
       onReroll(boss.id);
     }, 500);
@@ -77,6 +85,7 @@ function BossCard({ boss, onFace, onReroll }: BossCardProps) {
     const dx = e.clientX - startPos.current.x;
     const dy = e.clientY - startPos.current.y;
     if (Math.sqrt(dx * dx + dy * dy) > LONG_PRESS_MOVE_THRESHOLD) {
+      interactionCanceled.current = true;
       clearTimer();
       setPressing(false);
     }
@@ -85,19 +94,32 @@ function BossCard({ boss, onFace, onReroll }: BossCardProps) {
   const handlePointerUp = useCallback(() => {
     clearTimer();
     setPressing(false);
-    if (!didLongPress.current) {
+    if (!didLongPress.current && !interactionCanceled.current && !actionConsumed.current) {
+      actionConsumed.current = true;
       onFace(boss.id);
     }
+    interactionCanceled.current = false;
+    actionConsumed.current = false;
+    didLongPress.current = false;
+    startPos.current = null;
   }, [boss.id, onFace, clearTimer]);
 
   const handlePointerCancel = useCallback(() => {
+    interactionCanceled.current = true;
     clearTimer();
     setPressing(false);
+    didLongPress.current = false;
+    actionConsumed.current = false;
+    startPos.current = null;
   }, [clearTimer]);
 
   const handlePointerLeave = useCallback(() => {
+    interactionCanceled.current = true;
     clearTimer();
     setPressing(false);
+    didLongPress.current = false;
+    actionConsumed.current = false;
+    startPos.current = null;
   }, [clearTimer]);
 
   const handleKeyDown = useCallback(

--- a/src/components/BossGrid.tsx
+++ b/src/components/BossGrid.tsx
@@ -92,6 +92,7 @@ function BossCard({ boss, onFace, onReroll }: BossCardProps) {
   }, [clearTimer]);
 
   const handlePointerUp = useCallback(() => {
+    if (!startPos.current) return;
     clearTimer();
     setPressing(false);
     if (!didLongPress.current && !interactionCanceled.current && !actionConsumed.current) {

--- a/src/components/BossGrid.tsx
+++ b/src/components/BossGrid.tsx
@@ -64,6 +64,8 @@ function BossCard({ boss, onFace, onReroll }: BossCardProps) {
   }, [clearTimer]);
 
   const handlePointerDown = useCallback((e: PointerEvent) => {
+    if (startPos.current) return;
+    clearTimer();
     didLongPress.current = false;
     interactionCanceled.current = false;
     actionConsumed.current = false;
@@ -78,7 +80,7 @@ function BossCard({ boss, onFace, onReroll }: BossCardProps) {
       setPressing(false);
       onReroll(boss.id);
     }, 500);
-  }, [boss.id, onReroll]);
+  }, [boss.id, onReroll, clearTimer]);
 
   const handlePointerMove = useCallback((e: PointerEvent) => {
     if (!startPos.current) return;

--- a/src/components/BossGrid.tsx
+++ b/src/components/BossGrid.tsx
@@ -50,6 +50,7 @@ function BossCard({ boss, onFace, onReroll }: BossCardProps) {
   const interactionCanceled = useRef(false);
   const actionConsumed = useRef(false);
   const startPos = useRef<{ x: number; y: number } | null>(null);
+  const activePointerId = useRef<number | null>(null);
 
   const clearTimer = useCallback(() => {
     if (timerRef.current !== null) {
@@ -69,6 +70,7 @@ function BossCard({ boss, onFace, onReroll }: BossCardProps) {
     didLongPress.current = false;
     interactionCanceled.current = false;
     actionConsumed.current = false;
+    activePointerId.current = e.pointerId;
     startPos.current = { x: e.clientX, y: e.clientY };
     setPressing(true);
     timerRef.current = setTimeout(() => {
@@ -83,7 +85,7 @@ function BossCard({ boss, onFace, onReroll }: BossCardProps) {
   }, [boss.id, onReroll, clearTimer]);
 
   const handlePointerMove = useCallback((e: PointerEvent) => {
-    if (!startPos.current) return;
+    if (!startPos.current || e.pointerId !== activePointerId.current) return;
     const dx = e.clientX - startPos.current.x;
     const dy = e.clientY - startPos.current.y;
     if (Math.sqrt(dx * dx + dy * dy) > LONG_PRESS_MOVE_THRESHOLD) {
@@ -93,8 +95,8 @@ function BossCard({ boss, onFace, onReroll }: BossCardProps) {
     }
   }, [clearTimer]);
 
-  const handlePointerUp = useCallback(() => {
-    if (!startPos.current) return;
+  const handlePointerUp = useCallback((e: PointerEvent) => {
+    if (!startPos.current || e.pointerId !== activePointerId.current) return;
     clearTimer();
     setPressing(false);
     if (!didLongPress.current && !interactionCanceled.current && !actionConsumed.current) {
@@ -104,24 +106,29 @@ function BossCard({ boss, onFace, onReroll }: BossCardProps) {
     interactionCanceled.current = false;
     actionConsumed.current = false;
     didLongPress.current = false;
+    activePointerId.current = null;
     startPos.current = null;
   }, [boss.id, onFace, clearTimer]);
 
-  const handlePointerCancel = useCallback(() => {
+  const handlePointerCancel = useCallback((e: PointerEvent) => {
+    if (e.pointerId !== activePointerId.current) return;
     interactionCanceled.current = true;
     clearTimer();
     setPressing(false);
     didLongPress.current = false;
     actionConsumed.current = false;
+    activePointerId.current = null;
     startPos.current = null;
   }, [clearTimer]);
 
-  const handlePointerLeave = useCallback(() => {
+  const handlePointerLeave = useCallback((e: PointerEvent) => {
+    if (e.pointerId !== activePointerId.current) return;
     interactionCanceled.current = true;
     clearTimer();
     setPressing(false);
     didLongPress.current = false;
     actionConsumed.current = false;
+    activePointerId.current = null;
     startPos.current = null;
   }, [clearTimer]);
 


### PR DESCRIPTION
### Summary

This PR fixes two mobile interaction bugs in boss selection:

1. Fixes #7: Swiping on a boss card could incorrectly mark the boss as faced.
2. Fixes #8: A long-press reroll could be followed by an unintended action on finger release.

It also prepares patch release metadata for v1.0.1.

### What changed

- Updated gesture handling in `src/components/BossGrid.tsx`:
  - Added explicit interaction state to prioritize swipe behavior.
  - Canceled gameplay actions when movement exceeds threshold.
  - Enforced one action per pointer interaction.
  - Prevented face action after long-press reroll.
  - Reset interaction state consistently on pointer end/cancel/leave.
- Added regression tests in `src/components/BossGrid.test.tsx`:
  - Swipe beyond threshold triggers no face/reroll.
  - Long-press reroll fires once and does not face on release.
  - Quick tap still faces normally.
- Bumped version to `1.0.1` in `package.json`.
- Added `1.0.1` changelog entry and updated compare/release links in `CHANGELOG.md`.

### Why

Mobile gesture behavior should be predictable and safe:

- Swipe should behave like a gesture/scroll, not trigger gameplay.
- Long-press reroll should produce exactly one reroll action.
- Tap should continue to face as before.

### Testing

Executed locally:

1. `npm test` (pass)
2. `npm run typecheck` (pass)

Current test status:

- 8 test files passed
- 90 tests passed

### Release notes (v1.0.1)

- Fixed a mobile interaction bug where swiping on a boss card could incorrectly mark that boss as faced (Issue #7).
- Fixed a mobile interaction bug where a long-press reroll could be followed by an unintended boss action on finger release (Issue #8).